### PR TITLE
Prevent `read` from trimming whitespace, resulting in broken indentation

### DIFF
--- a/internal/globals.sh
+++ b/internal/globals.sh
@@ -511,7 +511,7 @@ function post_markdown {
 		cat "${TMP2}" > "${TMP1}"
 	else
 		HEADINGS=( )
-		while read LINE
+		while IFS= read -r LINE
 		do
 			if [[ "$(echo "${LINE}" | grep "^<h[[:digit:]]>.*</h[[:digit:]]>" )" == "" ]]
 			then


### PR DESCRIPTION
https://mywiki.wooledge.org/IFS