### PR TITLE
use nix provided cmark-gfm

### DIFF
--- a/doc/Home.md
+++ b/doc/Home.md
@@ -38,6 +38,10 @@ yourself in the new directory.
 
 ## `cmark-gfm` issue?
 
+If you're not using the nix-shell setup that automatically installs cmark-gfm
+and you also haven't provisioned it on your own, then note that ../internal contains
+prebuilt binaries for cmark-gfm for linux and macOS that might be useful.
+
 You might want to verify that the bundled copy works on your machine,
 especially if "Linux amd64" doesn't sound like a good description of your
 computer.

--- a/internal/set-programs.sh
+++ b/internal/set-programs.sh
@@ -15,7 +15,9 @@ GPG_SIGN_FLAGS="--yes --armor --detach-sign --local-user ${GPG_FINGERPRINT}"
 GPG_EXPORT_FLAGS="--armor --export ${GPG_FINGERPRINT}"
 RM="rm"
 RM_FLAGS="-fr"
-MARKDOWN="./internal/cmark-gfm"
+# have nix installed cmark-gfm
+# there are also cmark-gfm binaries built for linux and macOS in internal/
+MARKDOWN="$(which cmark-gfm)"
 # --unsafe is needed in order to render manually-entered HTML when generating
 # the table of contents. If you do not trust the markdown-formatted text
 # content of your blog (i.e. it isn't written by you), then it probably is not

--- a/internal/set-programs.sh
+++ b/internal/set-programs.sh
@@ -18,6 +18,8 @@ RM_FLAGS="-fr"
 # have nix installed cmark-gfm
 # there are also cmark-gfm binaries built for linux and macOS in internal/
 MARKDOWN="$(which cmark-gfm)"
+# if no cmark-gfm, fallback to the binary
+: "${MARKDOWN:="./internal/cmark-gfm"}"
 # --unsafe is needed in order to render manually-entered HTML when generating
 # the table of contents. If you do not trust the markdown-formatted text
 # content of your blog (i.e. it isn't written by you), then it probably is not

--- a/shell.nix
+++ b/shell.nix
@@ -2,5 +2,5 @@
 with pkgs;
 
 mkShell {
-  buildInputs = [ coreutils gnumake gnum4 ]; # packages here
+  buildInputs = [ coreutils gnumake gnum4 cmark-gfm ]; # packages here
 }


### PR DESCRIPTION
replaces using the self built binaries in ./internal, advantage being no manual binary switching when using a different OS. 

Should probably update documentation a bit. It would be ideal to have some tests but I don't know how that would work.